### PR TITLE
Issue 7 Version and Credit Dialogs

### DIFF
--- a/chessGame/src/main/java/edu/se181/AboutScreen.kt
+++ b/chessGame/src/main/java/edu/se181/AboutScreen.kt
@@ -1,21 +1,38 @@
 package edu.se181
 
+import edu.se181.StringSources.CREDITS
+import edu.se181.StringSources.CREDITS_DIALOG
 import edu.se181.StringSources.MAIN_MENU_SCREEN_PATH
+import edu.se181.StringSources.VERSION
+import edu.se181.StringSources.VERSION_DIALOG
 import javafx.event.ActionEvent
 import javafx.fxml.FXML
 import javafx.fxml.FXMLLoader
 import javafx.scene.Parent
+import javafx.scene.control.Alert
+import javafx.scene.control.Alert.AlertType
+
 
 class AboutScreen {
 
     @FXML
     private fun versionButtonAction(event: ActionEvent) {
-        //todo
+        val alert = Alert(AlertType.INFORMATION)
+        alert.title = VERSION_DIALOG
+        alert.headerText = null
+        alert.contentText = VERSION
+
+        alert.showAndWait()
     }
 
     @FXML
     private fun creditsButtonAction(event: ActionEvent) {
-        //todo
+        val alert = Alert(AlertType.INFORMATION)
+        alert.title = CREDITS_DIALOG
+        alert.headerText = null
+        alert.contentText = CREDITS
+
+        alert.showAndWait()
     }
 
     @FXML

--- a/chessGame/src/main/java/edu/se181/StringSources.kt
+++ b/chessGame/src/main/java/edu/se181/StringSources.kt
@@ -8,4 +8,15 @@ object StringSources {
 
     //UI Strings
     val CHESS = "Chess"
+    val CREDITS_DIALOG = "Credits"
+    val CREDITS = "Jackie Ni\n" +
+            "Torin Rittenhouse\n" +
+            "Tommy Santangelo\n" +
+            "Javion Smith-Sanders\n" +
+            "Samuel Tate\n" +
+            "Tim Tran"
+    private val VERSION_NUMBER = "0.0"
+    val VERSION = "Version: $VERSION_NUMBER"
+    val VERSION_DIALOG = "Version Info"
+
 }


### PR DESCRIPTION
Added functionality to the version and credit buttons to create dialogs to display
their respective information.  Dialogs were a simple way to just display that info
without any messing around in the already established ui.  Right now they look
pretty plain but if i have time and or motivation might try and make them look cool
other wise check the discord for a picture of them.