### PR TITLE
56-Pawn promotion popup screen and functionality

### DIFF
--- a/chessGame/src/main/java/edu/se181/Chessboard.java
+++ b/chessGame/src/main/java/edu/se181/Chessboard.java
@@ -1,6 +1,6 @@
 package edu.se181;
 
-import javafx.scene.Node;
+import javafx.scene.control.ChoiceDialog;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.*;
@@ -10,6 +10,7 @@ import javafx.scene.shape.Rectangle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 //Visual creation of the chessboard
@@ -150,32 +151,40 @@ public class Chessboard {
 
         for(Sprite sprites: blackPieces){
             sprites.setPosition(GridPane.getColumnIndex(sprites),GridPane.getRowIndex(sprites));
-            sprites.setOnMouseClicked(e->{
-                if(whiteTurn && whitePieces.contains(getSelectedPiece())){
-                    move(sprites.getXPos(),sprites.getYPos());
-                }
-                else if (!whiteTurn){
-                    setSelectedPiece(sprites);
-                    setSelectedLegalMoves(getLegalMoves(sprites));
-                }
-
-            });
+            addHandler(sprites, false);
         }
         for(Sprite sprites: whitePieces){
             sprites.setPosition(GridPane.getColumnIndex(sprites),GridPane.getRowIndex(sprites));
-            sprites.setOnMouseClicked(e->{
-                if(!whiteTurn && blackPieces.contains(getSelectedPiece())){
-                    move(sprites.getXPos(),sprites.getYPos());
-                }
-                else if (whiteTurn){
-                    setSelectedPiece(sprites);
-                    setSelectedLegalMoves(getLegalMoves(sprites));
-                }
-            });
+            addHandler(sprites, true);
         }
         board.getChildren().addAll(blackPieces);
         board.getChildren().addAll(whitePieces);
 
+    }
+
+    public void addHandler(Sprite sprite, boolean forWhite) {
+        if (forWhite) {
+            sprite.setOnMouseClicked(e->{
+                if(!whiteTurn && blackPieces.contains(getSelectedPiece())){
+                    move(sprite.getXPos(),sprite.getYPos());
+                }
+                else if (whiteTurn){
+                    setSelectedPiece(sprite);
+                    setSelectedLegalMoves(getLegalMoves(sprite));
+                }
+            });
+        } else {
+            sprite.setOnMouseClicked(e->{
+                if(whiteTurn && whitePieces.contains(getSelectedPiece())){
+                    move(sprite.getXPos(),sprite.getYPos());
+                }
+                else if (!whiteTurn){
+                    setSelectedPiece(sprite);
+                    setSelectedLegalMoves(getLegalMoves(sprite));
+                }
+
+            });
+        }
     }
 
     public void move(int x, int y){
@@ -183,26 +192,15 @@ public class Chessboard {
                 (!whiteTurn && whitePieces.contains(getSelectedPiece()))){
             return ;
         }
-        if (getSelectedLegalMoves().stream().noneMatch((Move m) -> m.getRankDest() == 7 - y && m.getFileDest() == x)) {
+        List<Move> moves = getSelectedLegalMoves().stream().filter((Move m) -> m.getRankDest() == 7 - y && m.getFileDest() == x).collect(Collectors.toList());
+        Move move;
+        if (moves.isEmpty()) {
             setSelectedPiece(null);
             getSelectedLegalMoves().clear();
             return ;
-        }
-        if(whiteTurn){
-            for(Sprite piece: blackPieces){
-                if(GridPane.getRowIndex(piece)==y && GridPane.getColumnIndex(piece)==x){
-                    remove(piece);
-                }
-            }
-        }
-        else{
-            for(Sprite piece: whitePieces){
-                if(GridPane.getRowIndex(piece)==y && GridPane.getColumnIndex(piece)==x){
-                    remove(piece);
-                }
-            }
-        }
-        Move move = getSelectedLegalMoves().stream().filter((Move m) -> m.getRankDest() == 7 - y && m.getFileDest() == x).collect(Collectors.toList()).get(0);
+        } else
+            move = moves.get(0);
+
         if (move instanceof EnPassantMove) {
             if (whiteTurn) {
                 Sprite pawn = blackPieces.stream().filter((Sprite s) -> s.getXPos() == x && s.getYPos() == y + 1).collect(Collectors.toList()).get(0);
@@ -212,7 +210,6 @@ public class Chessboard {
                 remove(pawn);
             }
         }
-        game.makeMove(move);
 
         if(move instanceof CastleMove){
             //move rook
@@ -245,6 +242,94 @@ public class Chessboard {
             System.out.println("here");
         }
 
+        if (move instanceof PromoteMove) {
+            List<String> promotePieces = new ArrayList<>();
+            String promotePieceString;
+            promotePieces.add("Queen");
+            promotePieces.add("Rook");
+            promotePieces.add("Bishop");
+            promotePieces.add("Knight");
+            ChoiceDialog<String> choiceDialog = new ChoiceDialog<>(promotePieces.get(0), promotePieces);
+            choiceDialog.setTitle("Pawn Promotion");
+            choiceDialog.setHeaderText("Select piece to promote pawn to");
+            Optional<String> result = choiceDialog.showAndWait();
+            if (result.isPresent()) {
+                promotePieceString = result.get();
+            } else {
+                setSelectedPiece(null);
+                getSelectedLegalMoves().clear();
+                return;
+            }
+            int pieceType = -1;
+            for (int i = 0; i < promotePieces.size(); i++) {
+                if (promotePieces.get(i).equals(promotePieceString)) {
+                    pieceType = i;
+                    break;
+                }
+            }
+            Piece promotePiece;
+            Sprite promotePieceSprite;
+            if (pieceType == 0) {
+                promotePiece = new Queen(7 - y, x, whiteTurn);
+                if (whiteTurn)
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getWHITE_QUEEN()));
+                else
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getBLACK_QUEEN()));
+            } else if (pieceType == 1) {
+                promotePiece = new Rook(7 - y, x, whiteTurn);
+                if (whiteTurn)
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getWHITE_ROOK()));
+                else
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getBLACK_ROOK()));
+            } else if (pieceType == 2) {
+                promotePiece = new Bishop(7 - y, x, whiteTurn);
+                if (whiteTurn)
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getWHITE_BISHOP()));
+                else
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getBLACK_BISHOP()));
+            } else {
+                promotePiece = new Knight(7 - y, x, whiteTurn);
+                if (whiteTurn)
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getWHITE_KNIGHT()));
+                else
+                    promotePieceSprite = new Sprite(new Image(StringSources.INSTANCE.getBLACK_KNIGHT()));
+            }
+            ((PromoteMove) move).setPromotePiece(promotePiece);
+            GridPane.setConstraints(promotePieceSprite, x, y);
+            if (whiteTurn) {
+                whitePieces.remove(getSelectedPiece());
+                whitePieces.add(promotePieceSprite);
+                System.out.println("setting event handler");
+            } else {
+                blackPieces.remove(getSelectedPiece());
+                blackPieces.add(promotePieceSprite);
+                System.out.println("setting event handler");
+            }
+            addHandler(promotePieceSprite, whiteTurn);
+            chessBoard.getChildren().remove(getSelectedPiece());
+            chessBoard.getChildren().add(promotePieceSprite);
+            setSelectedPiece(promotePieceSprite);
+        }
+
+        if(whiteTurn){
+            for(Sprite piece: blackPieces){
+                if(GridPane.getRowIndex(piece)==y && GridPane.getColumnIndex(piece)==x){
+                    remove(piece);
+                    break;
+                }
+            }
+        }
+        else{
+            for(Sprite piece: whitePieces){
+                if(GridPane.getRowIndex(piece)==y && GridPane.getColumnIndex(piece)==x){
+                    remove(piece);
+                    break;
+                }
+            }
+        }
+
+        game.makeMove(move);
+
         GridPane.setConstraints(getSelectedPiece(), x, y);
         getSelectedPiece().setPosition(x, y);
         setSelectedPiece(null);
@@ -255,10 +340,12 @@ public class Chessboard {
     public void remove(Sprite piece){
         chessBoard.getChildren().remove(piece);
         if(whiteTurn){
+            blackPieces.remove(piece);
             capturedBlackPieces.add(piece);
             blackCaptured.showPiece(piece);
         }
         else{
+            whitePieces.remove(piece);
             capturedWhitePieces.add(piece);
             whiteCaptured.showPiece(piece);
         }
@@ -285,6 +372,7 @@ public class Chessboard {
             System.out.print((char) (m.getFileDest() + 97));
             System.out.println((char) (m.getRankDest() + 49));
         }
+        System.out.println(game.halfMoveClock);
         System.out.println("----");
         return moves;
     }

--- a/chessGame/src/main/java/edu/se181/DrawChecker.java
+++ b/chessGame/src/main/java/edu/se181/DrawChecker.java
@@ -33,16 +33,16 @@ public class DrawChecker {
             return false;
         }
         for(int i = irreversibleMoveIndex; i < boardStateList.size(); i++){
-            boardState = boardStateList.get(i);
+            boardState = boardStateList.get(i).substring(2);
             checkWhite = i  % 2 == 0;
 
             if (checkWhite){
-                whiteBoardStateMap = updateHashMap(whiteBoardStateMap, boardState);
+                updateHashMap(whiteBoardStateMap, boardState);
                 if (whiteBoardStateMap.get(boardState) == 3){
                     return true;
                 }
             }else{
-                blackBoardStateMap = updateHashMap(blackBoardStateMap, boardState);
+                updateHashMap(blackBoardStateMap, boardState);
                 if (blackBoardStateMap.get(boardState) == 3){
                     return true;
                 }
@@ -51,14 +51,13 @@ public class DrawChecker {
         return false;
     }
 
-    private static HashMap<String, Integer> updateHashMap(HashMap<String, Integer> hashMap, String boardState){
+    private static void updateHashMap(HashMap<String, Integer> hashMap, String boardState){
         if (hashMap.containsKey(boardState)){
             hashMap.replace(boardState, hashMap.get(boardState)+1);
         }
         else{
             hashMap.put(boardState, 1);
         }
-        return hashMap;
     }
 
     public static boolean isDeadPosition(Board board){

--- a/chessGame/src/main/java/edu/se181/GameLogic.java
+++ b/chessGame/src/main/java/edu/se181/GameLogic.java
@@ -143,9 +143,13 @@ public class GameLogic {
         if (lastMoveWhite) {
             enemyPieces = board.getWhitePieces();
             king = (King) board.getBlackPieces().stream().filter((Piece p) -> p instanceof King).collect(Collectors.toList()).get(0);
+            for (Piece p : board.getBlackPieces())
+                p.setPinnedBy(null);
         } else {
             enemyPieces = board.getBlackPieces();
             king = (King) board.getWhitePieces().stream().filter((Piece p) -> p instanceof King).collect(Collectors.toList()).get(0);
+            for (Piece p : board.getWhitePieces())
+                p.setPinnedBy(null);
         }
         for (Piece piece : enemyPieces) {
             if (piece instanceof Bishop) {
@@ -607,17 +611,29 @@ public class GameLogic {
             // Filter king's legal squares to ones that opponent pieces can't move to
             if (piece.isWhite())
                 for (Piece other : board.getBlackPieces()) {
-                    moves = moves.stream()
-                            .filter((Move m) -> getBaseMoves(other, true)
-                                    .stream().noneMatch((Move m2) -> m.getRankDest() == m2.getRankDest() && m.getFileDest() == m2.getFileDest()))
-                            .collect(Collectors.toList());
+                    if (other instanceof Pawn) {
+                        moves = moves.stream()
+                                .filter((Move m) -> (m.getRankDest() != other.getRank() + (other.isWhite() ? 1 : -1)) || (m.getFileDest() != other.getFile() + 1 && m.getFileDest() != other.getFile() - 1))
+                                .collect(Collectors.toList());
+                    } else {
+                        moves = moves.stream()
+                                .filter((Move m) -> getBaseMoves(other, true)
+                                        .stream().noneMatch((Move m2) -> m.getRankDest() == m2.getRankDest() && m.getFileDest() == m2.getFileDest()))
+                                .collect(Collectors.toList());
+                    }
                 }
             else
                 for (Piece other : board.getWhitePieces()) {
-                    moves = moves.stream()
-                            .filter((Move m) -> getBaseMoves(other, true)
-                                    .stream().noneMatch((Move m2) -> m.getRankDest() == m2.getRankDest() && m.getFileDest() == m2.getFileDest()))
-                            .collect(Collectors.toList());
+                    if (other instanceof Pawn) {
+                        moves = moves.stream()
+                                .filter((Move m) -> (m.getRankDest() != other.getRank() + (other.isWhite() ? 1 : -1)) || (m.getFileDest() != other.getFile() + 1 && m.getFileDest() != other.getFile() - 1))
+                                .collect(Collectors.toList());
+                    } else {
+                        moves = moves.stream()
+                                .filter((Move m) -> getBaseMoves(other, true)
+                                        .stream().noneMatch((Move m2) -> m.getRankDest() == m2.getRankDest() && m.getFileDest() == m2.getFileDest()))
+                                .collect(Collectors.toList());
+                    }
                 }
             // Check in between square for check if castling
             List<Move> kingMoves = moves;


### PR DESCRIPTION
Added pawn promotion support in UI including an interface to select promoted piece
Fixed bug in threefold repetition determination as it was accidentally including en passant potential
Fixed bug in GameLogic getLegalMoves in which the King's moves got filtered on a Pawn's base moves and not its capture squares
Closes #56 
Closes #73 
Closes #74 